### PR TITLE
Updated entrypoint.sh to prevent script looping

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,4 +39,10 @@ done
 
 echo $(date): ${http_status}
 
+# Drain the node.
+# https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/#use-kubectl-drain-to-remove-a-node-from-service
 kubectl drain ${NODE_NAME}
+
+# Sleep for 120 seconds to prevent this script from looping.
+# The instance should be terminated by the end of the sleep.
+sleep 120


### PR DESCRIPTION
When a termination is detected, the script starts to loop, running the drain command multiple times unnecessarily. Since a spot instance has 2 minutes from termination detection to termination, 120 seconds should be a safe sleep interval.