### PR TITLE
Fix kubectl drain, K8s 1.6+ fixes

### DIFF
--- a/Dockerfile-1.6
+++ b/Dockerfile-1.6
@@ -1,0 +1,29 @@
+FROM alpine:3.4
+
+# Install kubectl
+# Note: Latest version may be found on:
+# https://aur.archlinux.org/packages/kubectl-bin/
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.5.3/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+
+ENV HOME=/config
+
+RUN set -x && \
+    apk add --no-cache curl ca-certificates && \
+    chmod +x /usr/local/bin/kubectl && \
+    \
+    # Create non-root user (with a randomly chosen UID/GUI).
+    adduser kubectl -Du 2342 -h /config && \
+    \
+    # Basic check it works.
+    kubectl version --client
+
+# Copy entrypoint.sh
+COPY entrypoint.sh /config/entrypoint.sh
+
+# Set permissions on the file.
+RUN chown kubectl: /config/entrypoint.sh && \
+    chmod +x /config/entrypoint.sh
+
+USER kubectl
+
+CMD ["/config/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 KUBE_VERSION ?= 1.3.3
-VERSION ?= 0.9.0
+VERSION ?= 0.9.1
 REPOSITORY ?= mumoshu/kube-spot-termination-notice-handler
 TAG ?= $(KUBE_VERSION)-$(VERSION)
 IMAGE ?= $(REPOSITORY):$(TAG)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Using the same version for your Kubernetes cluster and spot-termination-notice-h
 * `mumoshu/spot-termination-notice-handler:1.3.1`
 * `mumoshu/spot-termination-notice-handler:1.3.2`
 * `mumoshu/spot-termination-notice-handler:1.3.3`
+* `kylegato/spot-termination-notice-handler:1.5.3`
 
 ## Why use it
 

--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ Fri Jul 29 07:39:14 UTC 2016: 404
 ...
 Fri Jul 29 hh:mm:ss UTC 2016: 200
 ```
+
+## Kubernetes 1.6+
+
+Use Dockerfile-1.6 or image kylegato/spot-termination-notice-handler:1.5.3 for kubernetes clusters >=1.6

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,6 +43,6 @@ echo $(date): ${http_status}
 # https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/#use-kubectl-drain-to-remove-a-node-from-service
 kubectl drain ${NODE_NAME} --force --ignore-daemonsets
 
-# Sleep for 120 seconds to prevent this script from looping.
+# Sleep for 200 seconds to prevent this script from looping.
 # The instance should be terminated by the end of the sleep.
-sleep 120
+sleep 200

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ if [ "${POD_NAME}" == "" ]; then
   exit 1
 fi
 
-NODE_NAME=$(kubectl --namespace ${NAMESPACE} get pod ${POD_NAME} --output jsonpath="{.Spec.NodeName}")
+NODE_NAME=$(kubectl --namespace ${NAMESPACE} get pod ${POD_NAME} --output jsonpath="{.spec.nodeName}")
 
 if [ "${NODE_NAME}" == "" ]; then
   echo "[ERROR] Unable to fetch the name of the node running the pod \"${POD_NAME}\" in the namespace \"${NAMESPACE}\". Maybe a bug?: " 1>&2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ echo $(date): ${http_status}
 
 # Drain the node.
 # https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/#use-kubectl-drain-to-remove-a-node-from-service
-kubectl drain ${NODE_NAME}
+kubectl drain ${NODE_NAME} --force --ignore-daemonsets
 
 # Sleep for 120 seconds to prevent this script from looping.
 # The instance should be terminated by the end of the sleep.


### PR DESCRIPTION
This PR updates a few things as you can see from the commits:

- Sleep time after drain was raised from 120 to 200 seconds due to the fact that Amazon does not appear to *always* terminate at 120 seconds on the dot, so sometimes it would run twice.
- Added a Dockerfile for those who are using k8s 1.6+
- Updated entrypoint.sh script with a fix for grabbing the node name.
- Updated the README with this information.