### PR TITLE
Add more info to Slack message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 A Kubernetes DaemonSet to run 1 container per node to periodically polls the [EC2 Spot Instance Termination Notices](https://aws.amazon.com/jp/blogs/aws/new-ec2-spot-instance-termination-notices/) endpoint.
 Once a termination notice is received, it will try to gracefully stop all the pods running on the Kubernetes node, up to 2 minutes before the EC2 Spot Instance backing the node is terminated.
 
-## Usage
+## Installation
+
+### Manual
 
     $ kubectl create -f spot-termination-notice-handler.daemonset.yaml
 
-## Avaiable docker images/tags
+### Helm
+
+A helm chart has been created for this tool, and at time of writing was in the `incubator` repository.
+
+    $ helm install incubator/kube-spot-termination-notice-handler
+
+## Available docker images/tags
 
 Tags denotes Kubernetes/`kubectl` versions.
 Using the same version for your Kubernetes cluster and spot-termination-notice-handler is recommended.
@@ -22,7 +30,7 @@ Using the same version for your Kubernetes cluster and spot-termination-notice-h
 
 ## Why use it
 
-  * So that your kubernetes jobs backed by spot instances can keep running on another instances(typically on-demand instances)
+  * So that your kubernetes jobs backed by spot instances can keep running on another instances (typically on-demand instances)
 
 ## How it works
 
@@ -47,12 +55,12 @@ Fri Jul 29 hh:mm:ss UTC 2016: 200
 
 ## Building against a specific version of Kubernetes
 
-Run `KUBE_VERSION=<your disired k8s version> make build` to specify the version number of k8s/kubectl.
+Run `KUBE_VERSION=<your desired k8s version> make build` to specify the version number of k8s/kubectl.
 
 ## Slack Notifications
 Introduced in version 0.9.2 of this application, you are able to setup a Slack incoming web hook in order to send slack notifications to a channel, notifying the users that an instance has been terminated.
 
-Incoming WebHooks require that you set the SLACK_URL environmental variable as part of your PodSpec. 
+Incoming WebHooks require that you set the SLACK_URL environmental variable as part of your PodSpec.
 
 The URL should look something like: https://hooks.slack.com/services/T67UBFNHQ/B4Q7WQM52/1ctEoFjkjdjwsa22934
 
@@ -60,6 +68,9 @@ Slack Setup:
 * Docs: https://api.slack.com/incoming-webhooks
 * Setup: https://slack.com/apps/A0F7XDUAZ-incoming-webhooks
 
+
+Show where things are happening by setting the `CLUSTER` environment variable to whatever you call your cluster.
+Very handy if you have several clusters that report to the same Slack channel.
 
 Example Pod Spec:
 
@@ -75,6 +86,8 @@ Example Pod Spec:
                 fieldPath: metadata.namespace
           - name: SLACK_URL
             value: "https://hooks.slack.com/services/T67UBFNHQ/B4Q7WQM52/1ctEoFjkjdjwsa22934"
+          - name: CLUSTER
+            value: development
 ```
 
-![Example Slack Notification](http://i.imgur.com/UIUkyHv.png)
+![Example Slack Notification](http://i.imgur.com/UIUkyHv.png) (older version)


### PR DESCRIPTION
In a multi-cluster world, it'd be good to have the ability to see what's being terminated, more than just the hostname.

This PR adds Instance ID, AZ, and optionally (depending on an env var) cluster name to the Slack message.

The slack message is kept relatively short, so it should hopefully not span multiple lines of output.