### PR TITLE
RBAC: Allow Daemonset to run on rbac enabled cluster.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,8 @@ echo $(date): ${http_status}
 # The URL should look something like: https://hooks.slack.com/services/T67UBFNHQ/B4Q7WQM52/1ctEoFjkjdjwsa22934
 #
 if [ "${SLACK_URL}" != "" ]; then
-  SLACK_MESSAGE="Spot Termination Detected on node: $NODE_NAME"
+  RUNNING_PODS=$(kubectl get pods --all-namespaces -o wide | grep -v kube-system | egrep "${NODE_NAME}|NODE")
+  SLACK_MESSAGE="Spot Termination Detected on node: $NODE_NAME\nPods running:\n${RUNNING_PODS}"
   curl -X POST --data "payload={\"text\": \":warning: ${SLACK_MESSAGE}\"}" ${SLACK_URL}
 fi
 

--- a/spot-termination-notice-handler.daemonset.yaml
+++ b/spot-termination-notice-handler.daemonset.yaml
@@ -10,6 +10,8 @@ spec:
         app: spot-termination-notice-handler
       name: spot-termination-notice-handler
     spec:
+      serviceAccount: spot-termination-handler
+      serviceAccountName: spot-termination-handler
       containers:
       - image: mumoshu/kube-spot-termination-notice-handler:1.7.0-0.9.2
         imagePullPolicy: IfNotPresent
@@ -23,3 +25,40 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: spot-termination-handler
+roleRef:
+  kind: ClusterRole
+  name: spot-termination-handler
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: spot-termination-handler
+  namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: spot-termination-handler
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spot-termination-handler
+  namespace: kube-system


### PR DESCRIPTION
Allow RBAC enabled cluster to run this deamonset.

Enhanced Slack message contains evicted pod for the terminated node (useful for debugging later on)